### PR TITLE
[Bugfix] Fix MUI CSS taking precedence in Production

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import Footer from '@/components/footer/footer';
 import Header from '@/components/header/header';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter';
+import { StyledEngineProvider } from '@mui/material/styles';
 import { Lato } from 'next/font/google';
 import React from 'react';
 import './globals.scss';
@@ -15,9 +16,11 @@ export default function RootLayout({ children }: any) {
     <html lang="en">
       <body className={lato.className}>
         <Header />
-        <AppRouterCacheProvider options={{ enableCssLayer: true }}>
-          {children}
-        </AppRouterCacheProvider>
+        <StyledEngineProvider injectFirst>
+          <AppRouterCacheProvider options={{ enableCssLayer: true }}>
+            {children}
+          </AppRouterCacheProvider>
+        </StyledEngineProvider>
         <Footer />
       </body>
     </html>


### PR DESCRIPTION
Fixes #3 

Fixes styling issues with the Footer rendering correctly in Development, but not Production, due to different ordering when a NextJS Production build is made

Code changes were determined by following the MUI documentation here:

https://mui.com/material-ui/integrations/interoperability/#css-injection-order

Anyone logged into the CodeForBC Vercel account can view the build preview here:

https://vercel.live/link/codeforbc-web-git-bugfix-foot-2ac5d1-sam-huos-projects-45c5d2da.vercel.app?via=deployment-domains-list-branch

### Before PR

![image](https://github.com/CodeForBc/codeforbc-web/assets/16601729/a2275f8a-ac4a-4507-afe9-0e5616a7d388)

### After PR

![image](https://github.com/CodeForBc/codeforbc-web/assets/16601729/09ab6b76-d775-4b6c-b22f-60028f172aca)
