### PR TITLE
[Bugfix] Fix Compilation Warnings And Fix Header Mobile Layout

### DIFF
--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -3,6 +3,7 @@
 body {
   .header-outer-box {
     display: flex;
+    align-items: center;
     justify-content: center;
     box-shadow:
       0px 4px 6px -1px rgba(16, 24, 40, 0.1),

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -86,5 +86,12 @@ body {
     .Mui-selected {
       color: globals.$primary-color;
     }
+
+    @include globals.mobile {
+      a {
+        text-decoration: inherit;
+        color: inherit;
+      }
+    }
   }
 }

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -24,7 +24,7 @@ body {
     display: flex;
     flex-direction: column;
     row-gap: 0.4rem;
-    align-items: start;
+    align-items: flex-start;
   }
 
   .header-title {

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -1,6 +1,20 @@
 @use '../../app/globals';
 
 body {
+  .mobile-menu-btn {
+    display: none;
+
+    @include globals.mobile {
+      display: inherit;
+    }
+  }
+
+  .navigation-tab {
+    @include globals.mobile {
+      display: none;
+    }
+  }
+
   .header-outer-box {
     display: flex;
     align-items: center;
@@ -18,6 +32,10 @@ body {
         opacity: 0.25;
       }
     }
+
+    @include globals.mobile {
+      justify-content: space-between;
+    }
   }
 
   .header-inner-box {
@@ -25,7 +43,11 @@ body {
     display: flex;
     flex-direction: column;
     row-gap: 0.4rem;
-    align-items: flex-start;
+    align-items: start;
+
+    @include globals.mobile {
+      width: auto;
+    }
   }
 
   .header-title {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -86,7 +86,11 @@ function Header() {
             anchorEl={mobileMenuAnchor}
           >
             {headerData.map((tab, index) => (
-              <MenuItem onClick={handleClose} key={`menu-item-${index}`}>
+              <MenuItem
+                onClick={handleClose}
+                key={`menu-item-${index}`}
+                className="header-tab"
+              >
                 <Link href={tab.href}>{tab.label}</Link>
               </MenuItem>
             ))}

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import headerData from '@/components/header/header-data';
-import { Box, Link, Tab, Tabs } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import {
+  Box,
+  IconButton,
+  Link,
+  Menu,
+  MenuItem,
+  Tab,
+  Tabs,
+} from '@mui/material';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
@@ -15,6 +24,18 @@ function Header() {
   const [currentPath, setCurrentPath] = useState(
     pathToEnumMap[pathname] || false
   );
+
+  const [mobileMenuAnchor, setMobileMenuAnchor] = useState<HTMLElement | null>(
+    null
+  );
+  const mobileMenuOpen = Boolean(mobileMenuAnchor);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setMobileMenuAnchor(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setMobileMenuAnchor(null);
+  };
 
   useEffect(() => {
     setCurrentPath(pathToEnumMap[pathname] || false);
@@ -38,7 +59,11 @@ function Header() {
         />
       </Link>
       <Box className="header-inner-box">
-        <Tabs value={currentPath} onChange={handleChange}>
+        <Tabs
+          value={currentPath}
+          onChange={handleChange}
+          className="navigation-tab"
+        >
           {headerData.map((tab, index) => (
             <Tab
               key={index}
@@ -51,6 +76,22 @@ function Header() {
             />
           ))}
         </Tabs>
+        <Box className="mobile-menu-btn">
+          <IconButton onClick={handleClick}>
+            <MenuIcon />
+          </IconButton>
+          <Menu
+            onClose={handleClose}
+            open={mobileMenuOpen}
+            anchorEl={mobileMenuAnchor}
+          >
+            {headerData.map((tab, index) => (
+              <MenuItem onClick={handleClose} key={`menu-item-${index}`}>
+                <Link href={tab.href}>{tab.label}</Link>
+              </MenuItem>
+            ))}
+          </Menu>
+        </Box>
       </Box>
     </Box>
   );

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -29,16 +29,16 @@ function Header() {
 
   return (
     <Box component={'header'} className="header-outer-box">
+      <Link href="/" className="title-link">
+        <Image
+          src="./assets/logo.webp"
+          alt="Description"
+          width={64}
+          height={64}
+        />
+      </Link>
       <Box className="header-inner-box">
         <Tabs value={currentPath} onChange={handleChange}>
-          <Link href="/" className="title-link">
-            <Image
-              src="./assets/logo.webp"
-              alt="Description"
-              width={64}
-              height={64}
-            />
-          </Link>
           {headerData.map((tab, index) => (
             <Tab
               key={index}


### PR DESCRIPTION
While the app compiles and operates just fine, the current deployment emits some errors during the NextJS compilation step

I also fixed the way the `Header` renders on Mobile

### Before PR

<details>

<summary>Long NextJS Compilation Error Messages</summary>
$ codeforbc-web (main)
λ npm start

> codeforbc-web@0.1.0 start
> next dev

   ▲ Next.js 14.1.0
   - Local:        http://localhost:3000

   Using tsconfig file: ./tsconfig.json
 ✓ Ready in 2.3s
 ○ Compiling /about ...
 ⚠ ./src/components/header/header.scss.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[3]!./node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[11].oneOf[13].use[4]!./node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[11].oneOf[13].use[5]!./src/components/header/header.scss
Warning

(52:3) autoprefixer: start value has mixed support, consider using flex-start instead      

Import trace for requested module:
./src/components/header/header.scss.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[3]!./node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[11].oneOf[13].use[4]!./node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[11].oneOf[13].use[5]!./src/components/header/header.scss
./src/components/header/header.scss
./src/components/header/header.tsx
Warning: React does not recognize the `fullWidth` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `fullwidth` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at a
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Typography (webpack-internal:///(ssr)/./node_modules/@mui/material/Typography/Typography.js:112:89)
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Link (webpack-internal:///(ssr)/./node_modules/@mui/material/Link/Link.js:122:85)   
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Tabs (webpack-internal:///(ssr)/./node_modules/@mui/material/Tabs/Tabs.js:267:85)   
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Box (webpack-internal:///(ssr)/./node_modules/@mui/system/esm/createBox.js:34:76)   
    at header
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Box (webpack-internal:///(ssr)/./node_modules/@mui/system/esm/createBox.js:34:76)   
    at Header (webpack-internal:///(ssr)/./src/components/header/header.tsx:28:82)
    at Lazy
    at body
    at html
    at RedirectErrorBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/redirect-boundary.js:72:9)
    at RedirectBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/redirect-boundary.js:80:11)
    at ReactDevOverlay (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/react-dev-overlay/internal/ReactDevOverlay.js:84:9)
    at HotReload (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/react-dev-overlay/hot-reloader-client.js:308:11)
    at Router (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/app-router.js:176:11)
    at ErrorBoundaryHandler (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/error-boundary.js:113:9)
    at ErrorBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/error-boundary.js:159:11)
    at AppRouter (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/app-router.js:515:13)
    at Lazy
    at Lazy
    at rS (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:15614)
    at rS (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:15614)
    at ServerInsertedHTMLProvider (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:21176)
Warning: Received `false` for a non-boolean attribute `indicator`.

If you want to write it to the DOM, pass a string instead: indicator="false" or indicator={value.toString()}.

If you used to conditionally omit it with indicator={condition && value}, pass indicator={condition ? value : undefined} instead.
    at a
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Typography (webpack-internal:///(ssr)/./node_modules/@mui/material/Typography/Typography.js:112:89)
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Link (webpack-internal:///(ssr)/./node_modules/@mui/material/Link/Link.js:122:85)   
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Tabs (webpack-internal:///(ssr)/./node_modules/@mui/material/Tabs/Tabs.js:267:85)   
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Box (webpack-internal:///(ssr)/./node_modules/@mui/system/esm/createBox.js:34:76)   
    at header
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Box (webpack-internal:///(ssr)/./node_modules/@mui/system/esm/createBox.js:34:76)   
    at Header (webpack-internal:///(ssr)/./src/components/header/header.tsx:28:82)
    at Lazy
    at body
    at html
    at RedirectErrorBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/redirect-boundary.js:72:9)
    at RedirectBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/redirect-boundary.js:80:11)
    at ReactDevOverlay (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/react-dev-overlay/internal/ReactDevOverlay.js:84:9)
    at HotReload (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/react-dev-overlay/hot-reloader-client.js:308:11)
    at Router (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/app-router.js:176:11)
    at ErrorBoundaryHandler (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/error-boundary.js:113:9)
    at ErrorBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/error-boundary.js:159:11)
    at AppRouter (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/app-router.js:515:13)
    at Lazy
    at Lazy
    at rS (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:15614)
    at rS (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:15614)
    at ServerInsertedHTMLProvider (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:21176)
Warning: React does not recognize the `selectionFollowsFocus` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `selectionfollowsfocus` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at a
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Typography (webpack-internal:///(ssr)/./node_modules/@mui/material/Typography/Typography.js:112:89)
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Link (webpack-internal:///(ssr)/./node_modules/@mui/material/Link/Link.js:122:85)   
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Tabs (webpack-internal:///(ssr)/./node_modules/@mui/material/Tabs/Tabs.js:267:85)   
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Box (webpack-internal:///(ssr)/./node_modules/@mui/system/esm/createBox.js:34:76)   
    at header
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Box (webpack-internal:///(ssr)/./node_modules/@mui/system/esm/createBox.js:34:76)   
    at Header (webpack-internal:///(ssr)/./src/components/header/header.tsx:28:82)
    at Lazy
    at body
    at html
    at RedirectErrorBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/redirect-boundary.js:72:9)
    at RedirectBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/redirect-boundary.js:80:11)
    at ReactDevOverlay (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/react-dev-overlay/internal/ReactDevOverlay.js:84:9)
    at HotReload (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/react-dev-overlay/hot-reloader-client.js:308:11)
    at Router (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/app-router.js:176:11)
    at ErrorBoundaryHandler (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/error-boundary.js:113:9)
    at ErrorBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/error-boundary.js:159:11)
    at AppRouter (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/app-router.js:515:13)
    at Lazy
    at Lazy
    at rS (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:15614)
    at rS (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:15614)
    at ServerInsertedHTMLProvider (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:21176)
Warning: React does not recognize the `textColor` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `textcolor` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at a
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Typography (webpack-internal:///(ssr)/./node_modules/@mui/material/Typography/Typography.js:112:89)
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Link (webpack-internal:///(ssr)/./node_modules/@mui/material/Link/Link.js:122:85)   
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Tabs (webpack-internal:///(ssr)/./node_modules/@mui/material/Tabs/Tabs.js:267:85)   
    at div
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Box (webpack-internal:///(ssr)/./node_modules/@mui/system/esm/createBox.js:34:76)   
    at header
    at eval (webpack-internal:///(ssr)/./node_modules/@emotion/react/dist/emotion-element-6bdfffb2.esm.js:61:74)
    at Box (webpack-internal:///(ssr)/./node_modules/@mui/system/esm/createBox.js:34:76)   
    at Header (webpack-internal:///(ssr)/./src/components/header/header.tsx:28:82)
    at Lazy
    at body
    at html
    at RedirectErrorBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/redirect-boundary.js:72:9)
    at RedirectBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/redirect-boundary.js:80:11)
    at ReactDevOverlay (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/react-dev-overlay/internal/ReactDevOverlay.js:84:9)
    at HotReload (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/react-dev-overlay/hot-reloader-client.js:308:11)
    at Router (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/app-router.js:176:11)
    at ErrorBoundaryHandler (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/error-boundary.js:113:9)
    at ErrorBoundary (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/error-boundary.js:159:11)
    at AppRouter (webpack-internal:///(ssr)/./node_modules/next/dist/client/components/app-router.js:515:13)
    at Lazy
    at Lazy
    at rS (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:15614)
    at rS (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:15614)
    at ServerInsertedHTMLProvider (C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\next-server\app-page.runtime.dev.js:39:21176)
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\build\webpack\loaders\css-loader\src\index.js??ruleSet[1].rules[11].oneOf[13].use[2]!C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\build\webpack\loaders\postcss-loader\src\index.js??ruleSet[1].rules[11].oneOf[13].use[3]!C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\build\webpack\loaders\resolve-url-loader\index.js??ruleSet[1].rules[11].oneOf[13].use[4]!C:\Users\corre\projects\codeforbc-web\node_modules\next\dist\compiled\sass-loader\cjs.js??ruleSet[1].rules[11].oneOf[13].use[5]!C:\Users\corre\projects\codeforbc-web\src\components\header\header.scss': No serializer registered for Warning
<w> while serializing webpack/lib/cache/PackFileCacheStrategy.PackContentItems -> webpack/lib/NormalModule -> Array { 1 items } -> webpack/lib/ModuleWarning -> Warning
 ⚠ ./src/components/header/header.scss.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[3]!./node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[11].oneOf[13].use[4]!./node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[11].oneOf[13].use[5]!./src/components/header/header.scss
Warning

(52:3) autoprefixer: start value has mixed support, consider using flex-start instead      

Import trace for requested module:
./src/components/header/header.scss.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[3]!./node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[11].oneOf[13].use[4]!./node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[11].oneOf[13].use[5]!./src/components/header/header.scss
./src/components/header/header.scss
./src/components/header/header.tsx
 ⚠ ./src/components/header/header.scss.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[3]!./node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[11].oneOf[13].use[4]!./node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[11].oneOf[13].use[5]!./src/components/header/header.scss
Warning

(52:3) autoprefixer: start value has mixed support, consider using flex-start instead      

Import trace for requested module:
./src/components/header/header.scss.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[11].oneOf[13].use[3]!./node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[11].oneOf[13].use[4]!./node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[11].oneOf[13].use[5]!./src/components/header/header.scss
./src/components/header/header.scss
./src/components/header/header.tsx
</details>

![image](https://github.com/CodeForBc/codeforbc-web/assets/16601729/69a0d7de-3d0c-4a92-83f0-f20495b72b58)

### After PR

```
$ (bugfix/fix-compilation-errors)
λ npm start

> codeforbc-web@0.1.0 start
> next dev

   ▲ Next.js 14.1.0
   - Local:        http://localhost:3000

   Using tsconfig file: ./tsconfig.json
 ✓ Ready in 2.3s
 ○ Compiling / ...
 ✓ Compiled / in 3.3s (1902 modules)
```

![image](https://github.com/CodeForBc/codeforbc-web/assets/16601729/080f8054-2778-46ea-aac5-8afbe5b907dc)
