### PR TITLE
[SEO] robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
We only have 4 paths in the application at the moment:

```
/
/projects
/about
/join-us
```

There's no reason why any of them should be blocked by a Search Engine spider, hence an empty `Disallow`.

Furthermore, `Disallow` over `Allow` seems to be recommended for backwards compatibility purposes:

https://stackoverflow.com/a/44467157