### PR TITLE
[Tests] Update tests to be passing again

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,5 +19,5 @@ jobs:
           node-version: '18.x'
       - run: npm ci
       - run: npm run "lint:check"
-      # - run: npm run test
+      - run: npm run test
       - run: npm run build

--- a/src/__tests__/__snapshots__/header.snapshot.tsx.snap
+++ b/src/__tests__/__snapshots__/header.snapshot.tsx.snap
@@ -5,72 +5,79 @@ exports[`Header snapshot test should render header unchanged 1`] = `
   <header
     class="header-outer-box MuiBox-root css-0"
   >
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways title-link css-1xylxj1-MuiTypography-root-MuiLink-root"
+      href="/"
+    >
+      <img
+        alt="Description"
+        data-nimg="1"
+        decoding="async"
+        height="64"
+        loading="lazy"
+        src="./assets/codeforbc-logo.svg"
+        style="color: transparent;"
+        width="64"
+      />
+    </a>
     <div
       class="header-inner-box MuiBox-root css-0"
     >
-      <a
-        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways title-link css-1xylxj1-MuiTypography-root-MuiLink-root"
-        href="/"
+      <ul
+        class="nav__header"
       >
-        CodeForBC
-      </a>
-      <div
-        class="MuiTabs-root css-1ujnqem-MuiTabs-root"
-      >
-        <div
-          class="MuiTabs-scroller MuiTabs-fixed css-jpln7h-MuiTabs-scroller"
-          style="overflow: hidden; margin-bottom: 0px;"
+        <li
+          class="nav__list"
         >
-          <div
-            class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
-            role="tablist"
+          <a
+            href="/projects"
           >
-            <a
-              aria-selected="false"
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary header-tab css-16hexql-MuiTypography-root-MuiLink-root-MuiButtonBase-root-MuiTab-root"
-              href="/projects"
-              role="button"
-              tabindex="0"
-            >
-              Projects
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
-            </a>
-            <a
-              aria-selected="false"
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary header-tab css-16hexql-MuiTypography-root-MuiLink-root-MuiButtonBase-root-MuiTab-root"
-              href="/join-us"
-              role="button"
-              tabindex="-1"
-            >
-              Join Us
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
-            </a>
-            <a
-              aria-selected="false"
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary header-tab css-16hexql-MuiTypography-root-MuiLink-root-MuiButtonBase-root-MuiTab-root"
-              href="/about"
-              role="button"
-              tabindex="-1"
-            >
-              About
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
-            </a>
-          </div>
+            Our Projects
+          </a>
+        </li>
+        <li
+          class="nav__list"
+        >
+          <a
+            href="/about"
+          >
+            Who We Are
+          </a>
+        </li>
+        <li
+          class="nav__list"
+        >
+          <a
+            href="/join-us"
+          >
+            Join Us!
+          </a>
+        </li>
+      </ul>
+      <div
+        class="mobile-menu-btn MuiBox-root css-0"
+      >
+        <button
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="MenuIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M3 18h18v-2H3zm0-5h18v-2H3zm0-7v2h18V6z"
+            />
+          </svg>
           <span
-            class="MuiTabs-indicator css-1aquho2-MuiTabs-indicator"
-            style="left: 0px; width: 0px;"
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
-        </div>
+        </button>
       </div>
-      <nav
-        class="header-nav MuiBox-root css-0"
-      />
     </div>
   </header>
 </div>

--- a/src/app/about/about.page.test.tsx
+++ b/src/app/about/about.page.test.tsx
@@ -1,12 +1,12 @@
+import About from '@/app/about/page';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
-import About from '@/app/about/page';
 
 describe('About Page', () => {
-  it('should render title', () => {
-    render(<About />);
-    const title = screen.getByText('About');
+  it('should render title', async () => {
+    // About is an async component, so we need to await it
+    render(await About());
+    const title = screen.getByRole('heading', { name: 'Meet Our Team' });
     expect(title).toBeInTheDocument();
   });
 });

--- a/src/app/join-us/page.client.tsx
+++ b/src/app/join-us/page.client.tsx
@@ -28,7 +28,7 @@ export default function JoinUs() {
           <Box className="join-us-banner">
             <Box className="join-us-banner__image-container">
               <Image
-                src="./assets/join-us-hero.png"
+                src="/assets/join-us-hero.png"
                 alt="Description"
                 width={500}
                 height={500}

--- a/src/components/banner/banner.test.tsx
+++ b/src/components/banner/banner.test.tsx
@@ -5,7 +5,9 @@ import { render, screen } from '@testing-library/react';
 describe('Banner component', () => {
   it('renders banner heading', () => {
     render(<Banner />);
-    const bannerHeading = screen.getByText('Be a Force For Good in BC!');
+    const bannerHeading = screen.getByRole('heading', {
+      name: 'Be a Force For Good in BC!',
+    });
     expect(bannerHeading).toBeInTheDocument();
   });
 

--- a/src/components/core-values/core-values.tsx
+++ b/src/components/core-values/core-values.tsx
@@ -61,7 +61,7 @@ export default function CoreValues() {
         </Box>
         <Box className="core-value__image-container">
           <Image
-            src="./assets/core-values.png"
+            src="/assets/core-values.png"
             alt="Description"
             width={562}
             height={422}

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -15,14 +15,14 @@ describe('Header', () => {
   it('should render navigation buttons', () => {
     render(<Header />);
 
-    const projectNav = screen.getByRole('button', {
-      name: 'Projects',
+    const projectNav = screen.getByRole('link', {
+      name: 'Our Projects',
     });
-    const joinUsNav = screen.getByRole('button', {
-      name: 'Join Us',
+    const joinUsNav = screen.getByRole('link', {
+      name: 'Join Us!',
     });
-    const aboutNav = screen.getByRole('button', {
-      name: 'About',
+    const aboutNav = screen.getByRole('link', {
+      name: 'Who We Are',
     });
 
     expect(projectNav).toBeInTheDocument();

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -2,7 +2,6 @@ import headerData from '@/components/header/header-data';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import HeaderEnum from '../../enum/header-enum';
 import Header from './header';
 
 describe('Header', () => {
@@ -44,14 +43,5 @@ describe('Header', () => {
     });
 
     expect(hasDuplicate).toBe(false);
-  });
-
-  it('should have enum values as unique numbers', () => {
-    expect(typeof HeaderEnum.projects).toBe('number');
-    expect(typeof HeaderEnum.joinUs).toBe('number');
-    expect(typeof HeaderEnum.about).toBe('number');
-    expect(HeaderEnum.projects).not.toEqual(HeaderEnum.joinUs);
-    expect(HeaderEnum.projects).not.toEqual(HeaderEnum.about);
-    expect(HeaderEnum.joinUs).not.toEqual(HeaderEnum.about);
   });
 });


### PR DESCRIPTION
Fixes #44

Code coverage isn't at 100%, but we can at least safely turn tests back on for GitHub Actions.

```
$ npm run test

> codeforbc-web@0.1.0 test
> jest

   Using tsconfig file: ./tsconfig.json
 PASS  src/client-services/github.client-service.test.tsx
 PASS  src/utils/get-project-status-color/get-project-status-color.test.tsx
 PASS  src/utils/get-local-project-data/get-local-project-data.test.tsx
 PASS  src/__tests__/github.mapping.test.ts
 PASS  src/app/page.test.tsx
 PASS  src/__tests__/header.snapshot.tsx
 PASS  src/components/project-overview/project-overview.test.tsx
 PASS  src/app/_component/home-page.test.tsx
 PASS  src/app/projects/projects.page.test.tsx
 PASS  src/components/header/header.test.tsx
 PASS  src/app/about/about.page.test.tsx
 PASS  src/components/banner/banner.test.tsx                                                                                                                                                                                    
 PASS  src/app/join-us/join-us.page.test.tsx
--------------------------------|---------|----------|---------|---------|-------------------
File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------------|---------|----------|---------|---------|-------------------
All files                       |   89.94 |    85.71 |   88.37 |    91.3 |                   
 app                            |   35.71 |      100 |      50 |   30.76 |                   
  layout.tsx                    |       0 |      100 |       0 |       0 | 1-14              
  page.tsx                      |     100 |      100 |     100 |     100 |                   
 app/_component                 |     100 |      100 |     100 |     100 |                                                                                                                                                      
  home-page.tsx                 |     100 |      100 |     100 |     100 |                                                                                                                                                      
 app/about                      |   92.85 |      100 |     100 |     100 |                                                                                                                                                      
  page.tsx                      |   92.85 |      100 |     100 |     100 |                   
 app/join-us                    |   92.85 |      100 |     100 |     100 | 
  page.client.tsx               |     100 |      100 |     100 |     100 | 
  page.tsx                      |      80 |      100 |     100 |     100 | 
 app/projects                   |      90 |      100 |     100 |     100 | 
  page.tsx                      |      90 |      100 |     100 |     100 | 
 client-services                |     100 |       50 |     100 |     100 | 
  github.client-service.ts      |     100 |       50 |     100 |     100 | 29
 components/banner              |     100 |      100 |     100 |     100 | 
  banner.tsx                    |     100 |      100 |     100 |     100 | 
 components/core-values         |     100 |      100 |     100 |     100 | 
  core-values-data.tsx          |     100 |      100 |     100 |     100 | 
  core-values.tsx               |     100 |      100 |     100 |     100 | 
 components/faq                 |     100 |      100 |     100 |     100 | 
  faq-data.tsx                  |     100 |      100 |     100 |     100 | 
  faq.tsx                       |     100 |      100 |     100 |     100 | 
 components/footer              |       0 |      100 |       0 |       0 | 
  footer.tsx                    |       0 |      100 |       0 |       0 | 3-88
 components/header              |    90.9 |      100 |      60 |      90 | 
  header-data.tsx               |     100 |      100 |     100 |     100 | 
  header.tsx                    |   89.47 |      100 |      60 |   88.88 | 26,30
 components/join-us-tab         |   94.11 |       50 |      75 |   93.33 | 
  join-us-tab-data.tsx          |     100 |      100 |     100 |     100 | 
  join-us-tab.tsx               |    92.3 |       50 |      75 |    92.3 | 21
 components/project-card        |     100 |      100 |     100 |     100 | 
  project-card.tsx              |     100 |      100 |     100 |     100 | 
 components/project-overview    |     100 |       50 |     100 |     100 | 
  project-overview.tsx          |     100 |       50 |     100 |     100 | 11
 components/question-and-answer |     100 |      100 |     100 |     100 | 
  question-and-answer.tsx       |     100 |      100 |     100 |     100 | 
 components/team-bio-card       |     100 |      100 |     100 |     100 | 
  team-bio-card.tsx             |     100 |      100 |     100 |     100 | 
 mapper                         |     100 |      100 |     100 |     100 | 
  github.mapping.ts             |     100 |      100 |     100 |     100 | 
 utils/get-local-project-data   |     100 |      100 |     100 |     100 | 
  get-local-project-data.tsx    |     100 |      100 |     100 |     100 | 
 utils/get-project-status-color |     100 |      100 |     100 |     100 | 
  get-project-status-color.tsx  |     100 |      100 |     100 |     100 | 
 utils/get-team-members-data    |     100 |      100 |     100 |     100 | 
  get-team-members-data.tsx     |     100 |      100 |     100 |     100 | 
--------------------------------|---------|----------|---------|---------|-------------------

Test Suites: 13 passed, 13 total
Tests:       28 passed, 28 total
Snapshots:   1 passed, 1 total
Time:        5.331 s
Ran all test suites.
```